### PR TITLE
VDSO issue for arm64 has fixed on RHEL8.5

### DIFF
--- a/arch/arm64/kernel/vdso.c
+++ b/arch/arm64/kernel/vdso.c
@@ -150,7 +150,7 @@ int arch_map_vdso(struct process_vm *vm)
 	}
 
 	start = vdso_base;
-	end = vdso_base + PAGE_SIZE;
+	end = vdso_base + 2*PAGE_SIZE;
 	flag = VR_REMOTE | VR_PROT_READ;
 	flag |= VRFLAG_PROT_TO_MAXPROT(flag);
 	ret = add_process_memory_range(vm, start, end, vdso.vvar_phys, flag,

--- a/executer/user/lib/libdwarf/CMakeLists.txt
+++ b/executer/user/lib/libdwarf/CMakeLists.txt
@@ -139,6 +139,7 @@ if (NOT LIBDWARF)
 		DEPENDS gennames libdwarf/libdwarf/libdwarf.h.in)
 
 	add_library(dwarf STATIC ${DWARF_SOURCES} ${GENNAMES_OUTPUT} ${DWARF_CONFIGURATION_FILES})
+	target_compile_options(dwarf PRIVATE -fPIC)
 	target_include_directories(dwarf PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/libdwarf/libdwarf/")
 	target_include_directories(dwarf BEFORE PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 endif()

--- a/kernel/procfs.c
+++ b/kernel/procfs.c
@@ -471,7 +471,7 @@ static int _process_procfs_request(struct ikc_scd_packet *rpacket, int *result)
 				 range->start == (unsigned long)vm->vdso_addr ?
 					"[vdso]" :
 				 range->start == (unsigned long)vm->vvar_addr ?
-					"[vsyscall]" :
+					"[vvar]" :
 				 range->flag & VR_STACK ?
 					"[stack]" :
 				 range->start >= vm->region.brk_start &&


### PR DESCRIPTION
The VDSO issue for arm64 has been fixed on RHEL8.5.
Also, fixed compiling issue of libdwarf.